### PR TITLE
Allow copy of user input text

### DIFF
--- a/init.js
+++ b/init.js
@@ -13,6 +13,7 @@
   https://sethusenthil.com
   `)
 
+  const USER_TEXT_SELECTOR = '.items-start';
   const CHAT_TEXT_SELECTOR = '.markdown';
   const CLIPBOARD_CLASS_NAME = 'copy-to-clipboard';
 
@@ -81,10 +82,19 @@
       //console.log('chatbox', chatbox);
       //first chat box needs to be from user, hence all the even chat bubbles are from bot
       //plus users will have the first row as model selection
+      let text_selector;
       if ((i > 0 && (i % 2 === 0) && plusUser) ||
         ((i + 1) % 2 === 0 && !plusUser)) {
+        text_selector = CHAT_TEXT_SELECTOR;
+      } else if ((i > 0 && (i % 2 === 1) && plusUser) ||
+      ((i + 1) % 2 === 1 && !plusUser)) {
+        text_selector = USER_TEXT_SELECTOR;
+      } else {
+        text_selector = undefined;
+      }
+      if (text_selector !== undefined) {
         //it is a chat box from bot
-        const addAfter = chatbox.querySelector(CHAT_TEXT_SELECTOR);
+        const addAfter = chatbox.querySelector(text_selector);
 
         if (chatbox.querySelector(`.${CLIPBOARD_CLASS_NAME}`) === null) {
 
@@ -95,7 +105,7 @@
           </div>`);
           chatbox.querySelector(`.${CLIPBOARD_CLASS_NAME}`).addEventListener('click', function () {
 
-            const text = chatbox.querySelector(CHAT_TEXT_SELECTOR).innerText;
+            const text = chatbox.querySelector(text_selector).innerText;
             copyToClipboard(text);
 
           });

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,7 @@
   transition: 0.3s;
   display: flex;
   align-items: center;
+  width: fit-content;
 }
 
 .emoji {


### PR DESCRIPTION
Feature:
- Add ability to copy user chats

Use Case:
I frequently continue the conversation with ChatGPT by copying my own chats and modifying them slightly. For example, I use ChatGPT for SEO keyword research and I ask ChatGPT to generate sub-topics for me for specific topics. I will then iterate through my list of topics asking it to generate sub-topics for each.


Sethu,

I was going to request this feature, but I decided to implement it myself. I've tested the change in my own Edge browser. I now have the ability to copy my own chats. I'm sure this feature will help others, but it's ultimately up to you whether you want to include this feature in the mainstream extension.

Thanks,
Dan Schaefer